### PR TITLE
fix error with call cp

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -22,7 +22,7 @@ FileUtils.chdir APP_ROOT do
   #   FileUtils.cp "config/database.yml.sample", "config/database.yml"
   # end
   unless File.exist?("config/secrets.yml")
-    cp "config/secrets.yml.sample", "config/secrets.yml"
+    FileUtils.cp "config/secrets.yml.sample", "config/secrets.yml"
   end
 
   puts "\n== Preparing database =="


### PR DESCRIPTION
if we call cp in same, we have 
bin/setup:25:in `block in <main>': undefined method `cp' for main:Object (NoMethodError)